### PR TITLE
Enhance error handling in main and add tests for panic recovery and C…

### DIFF
--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRun_PanicRecovery(t *testing.T) {
+	t.Parallel()
+
+	// --- Arrange ---
+	// Define an HCL string with a syntax error that is guaranteed to cause a panic
+	// during the loading phase inside app.NewApp().
+	invalidHCL := `
+		step "print" "A" {
+			arguments {
+		// Missing closing brace here
+	`
+	// Create a temporary directory and file to hold the invalid config.
+	tempDir := t.TempDir()
+	filePath := filepath.Join(tempDir, "main.hcl")
+	err := os.WriteFile(filePath, []byte(invalidHCL), 0600)
+	require.NoError(t, err, "failed to set up test file")
+
+	// Prepare the arguments for the run function.
+	args := []string{filePath}
+	out := &bytes.Buffer{}
+
+	// --- Act ---
+	// Call the run function, which should recover the panic and return it as an error.
+	runErr := run(out, args)
+
+	// --- Assert ---
+	require.Error(t, runErr, "run() should have returned an error after recovering from a panic")
+
+	errStr := runErr.Error()
+	require.True(t, strings.Contains(errStr, "application startup panicked"), "The error message should indicate that a panic was recovered.")
+	require.True(t, strings.Contains(errStr, "failed to parse"), "The error message should contain the underlying reason for the panic.")
+}

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -42,3 +42,37 @@ func TestRun_PanicRecovery(t *testing.T) {
 	require.True(t, strings.Contains(errStr, "application startup panicked"), "The error message should indicate that a panic was recovered.")
 	require.True(t, strings.Contains(errStr, "failed to parse"), "The error message should contain the underlying reason for the panic.")
 }
+
+func TestRun_ShouldExit(t *testing.T) {
+	t.Parallel()
+
+	// --- Arrange ---
+	// The "-h" (help) flag should cause cli.Parse to return `shouldExit=true`.
+	args := []string{"-h"}
+	out := &bytes.Buffer{}
+
+	// --- Act ---
+	// The run function should see `shouldExit=true` and return a nil error.
+	err := run(out, args)
+
+	// --- Assert ---
+	require.NoError(t, err, "run() should return a nil error when shouldExit is true")
+	require.Contains(t, out.String(), "Usage:", "Expected help text to be printed to the output buffer")
+}
+
+func TestRun_ParseError(t *testing.T) {
+	t.Parallel()
+
+	// --- Arrange ---
+	// Providing an unknown flag will cause cli.Parse to return an error.
+	args := []string{"--this-is-not-a-valid-flag"}
+	out := &bytes.Buffer{}
+
+	// --- Act ---
+	// The run function should propagate the error from cli.Parse.
+	err := run(out, args)
+
+	// --- Assert ---
+	require.Error(t, err, "run() should return an error when argument parsing fails")
+	require.Contains(t, err.Error(), "flag provided but not defined: -this-is-not-a-valid-flag")
+}

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -4,75 +4,89 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestRun_PanicRecovery(t *testing.T) {
+func TestRun(t *testing.T) {
 	t.Parallel()
 
-	// --- Arrange ---
-	// Define an HCL string with a syntax error that is guaranteed to cause a panic
-	// during the loading phase inside app.NewApp().
-	invalidHCL := `
-		step "print" "A" {
-			arguments {
-		// Missing closing brace here
-	`
-	// Create a temporary directory and file to hold the invalid config.
-	tempDir := t.TempDir()
-	filePath := filepath.Join(tempDir, "main.hcl")
-	err := os.WriteFile(filePath, []byte(invalidHCL), 0600)
-	require.NoError(t, err, "failed to set up test file")
+	// --- Test Case Definitions ---
+	testCases := []struct {
+		name        string
+		args        []string
+		setup       func(t *testing.T) (args []string, cleanup func())
+		checkErr    func(t *testing.T, err error)
+		checkOutput func(t *testing.T, output string)
+	}{
+		{
+			name: "Success Path - Should Exit Cleanly",
+			args: []string{"-h"},
+			checkErr: func(t *testing.T, err error) {
+				require.NoError(t, err, "run() should not return an error for a clean exit")
+			},
+			checkOutput: func(t *testing.T, output string) {
+				require.Contains(t, output, "Usage:")
+			},
+		},
+		{
+			name: "Error Path - Argument Parsing Fails",
+			args: []string{"--invalid-flag"},
+			checkErr: func(t *testing.T, err error) {
+				require.Error(t, err, "run() should return an error for a parsing failure")
+				require.Contains(t, err.Error(), "flag provided but not defined: -invalid-flag")
+			},
+		},
+		{
+			name: "Error Path - Recovers from Panic",
+			setup: func(t *testing.T) (args []string, cleanup func()) {
+				// Create a syntactically invalid HCL file that will cause a panic
+				invalidHCL := `step "print" "A" { arguments {`
+				tempDir := t.TempDir()
+				filePath := filepath.Join(tempDir, "main.hcl")
+				err := os.WriteFile(filePath, []byte(invalidHCL), 0600)
+				require.NoError(t, err)
 
-	// Prepare the arguments for the run function.
-	args := []string{filePath}
-	out := &bytes.Buffer{}
+				// The test will run with the path to this file as its argument
+				return []string{filePath}, func() { os.RemoveAll(tempDir) }
+			},
+			checkErr: func(t *testing.T, err error) {
+				require.Error(t, err, "run() should have returned an error after recovering from a panic")
+				errStr := err.Error()
+				require.Contains(t, errStr, "application startup panicked")
+				require.Contains(t, errStr, "failed to parse")
+			},
+		},
+	}
 
-	// --- Act ---
-	// Call the run function, which should recover the panic and return it as an error.
-	runErr := run(out, args)
+	// --- Test Runner ---
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	// --- Assert ---
-	require.Error(t, runErr, "run() should have returned an error after recovering from a panic")
+			// --- Arrange ---
+			out := &bytes.Buffer{}
+			args := tc.args
 
-	errStr := runErr.Error()
-	require.True(t, strings.Contains(errStr, "application startup panicked"), "The error message should indicate that a panic was recovered.")
-	require.True(t, strings.Contains(errStr, "failed to parse"), "The error message should contain the underlying reason for the panic.")
-}
+			if tc.setup != nil {
+				var cleanup func()
+				args, cleanup = tc.setup(t)
+				if cleanup != nil {
+					t.Cleanup(cleanup)
+				}
+			}
 
-func TestRun_ShouldExit(t *testing.T) {
-	t.Parallel()
+			// --- Act ---
+			err := run(out, args)
 
-	// --- Arrange ---
-	// The "-h" (help) flag should cause cli.Parse to return `shouldExit=true`.
-	args := []string{"-h"}
-	out := &bytes.Buffer{}
-
-	// --- Act ---
-	// The run function should see `shouldExit=true` and return a nil error.
-	err := run(out, args)
-
-	// --- Assert ---
-	require.NoError(t, err, "run() should return a nil error when shouldExit is true")
-	require.Contains(t, out.String(), "Usage:", "Expected help text to be printed to the output buffer")
-}
-
-func TestRun_ParseError(t *testing.T) {
-	t.Parallel()
-
-	// --- Arrange ---
-	// Providing an unknown flag will cause cli.Parse to return an error.
-	args := []string{"--this-is-not-a-valid-flag"}
-	out := &bytes.Buffer{}
-
-	// --- Act ---
-	// The run function should propagate the error from cli.Parse.
-	err := run(out, args)
-
-	// --- Assert ---
-	require.Error(t, err, "run() should return an error when argument parsing fails")
-	require.Contains(t, err.Error(), "flag provided but not defined: -this-is-not-a-valid-flag")
+			// --- Assert ---
+			if tc.checkErr != nil {
+				tc.checkErr(t, err)
+			}
+			if tc.checkOutput != nil {
+				tc.checkOutput(t, out.String())
+			}
+		})
+	}
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,0 +1,133 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+	"github.com/vk/burstgridgo/internal/app"
+)
+
+func TestParse(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		args           []string
+		expectExit     bool
+		expectErr      bool
+		expectedConfig *app.AppConfig
+		checkOutput    func(t *testing.T, output string)
+	}{
+		{
+			name: "Happy Path with all flags",
+			args: []string{
+				"-grid", "/test/grid",
+				"--modules-path=/test/modules",
+				"--log-level=debug",
+				"--log-format=text",
+				"--workers=50",
+				"--healthcheck-port=8080",
+			},
+			expectedConfig: &app.AppConfig{
+				GridPath:        "/test/grid",
+				ModulesPath:     "/test/modules",
+				LogLevel:        "debug",
+				LogFormat:       "text",
+				WorkerCount:     50,
+				HealthcheckPort: 8080,
+			},
+		},
+		{
+			name:       "Shorthand flag and defaults",
+			args:       []string{"-g", "/short/path"},
+			expectExit: false,
+			expectErr:  false,
+			expectedConfig: &app.AppConfig{
+				GridPath:        "/short/path",
+				ModulesPath:     "modules",
+				LogLevel:        "info",
+				LogFormat:       "json",
+				WorkerCount:     10,
+				HealthcheckPort: 0,
+			},
+		},
+		{
+			name:       "Positional argument for path",
+			args:       []string{"/positional/path"},
+			expectExit: false,
+			expectErr:  false,
+			expectedConfig: &app.AppConfig{
+				GridPath:        "/positional/path",
+				ModulesPath:     "modules",
+				LogLevel:        "info",
+				LogFormat:       "json",
+				WorkerCount:     10,
+				HealthcheckPort: 0,
+			},
+		},
+		{
+			name:       "Help flag triggers clean exit",
+			args:       []string{"-h"},
+			expectExit: true,
+			expectErr:  false,
+			checkOutput: func(t *testing.T, output string) {
+				require.True(t, strings.Contains(output, "Usage:"), "Expected help text to be printed")
+			},
+		},
+		{
+			name:       "No path triggers clean exit with usage",
+			args:       []string{},
+			expectExit: true,
+			expectErr:  false,
+			checkOutput: func(t *testing.T, output string) {
+				require.True(t, strings.Contains(output, "Usage:"), "Expected help text to be printed")
+			},
+		},
+		{
+			name:      "Invalid log level returns an error",
+			args:      []string{"--log-level=foo", "/path"},
+			expectErr: true,
+		},
+		{
+			name:      "Invalid log format returns an error",
+			args:      []string{"--log-format=yaml", "/path"},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// --- Arrange ---
+			out := &bytes.Buffer{}
+
+			// --- Act ---
+			appConfig, shouldExit, err := Parse(tc.args, out)
+
+			// --- Assert ---
+			if tc.expectErr {
+				require.Error(t, err)
+				_, isExitError := err.(*ExitError)
+				require.True(t, isExitError, "Expected error to be of type ExitError")
+				return // End test here if an error is expected
+			}
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expectExit, shouldExit)
+
+			if tc.expectedConfig != nil {
+				if diff := cmp.Diff(tc.expectedConfig, appConfig); diff != "" {
+					t.Errorf("AppConfig mismatch (-want +got):\n%s", diff)
+				}
+			}
+
+			if tc.checkOutput != nil {
+				tc.checkOutput(t, out.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request improves error handling and test coverage for the CLI application. The key changes include enhancing panic recovery in the `run` function, adding comprehensive unit tests for `run` and `cli.Parse`, and refining error messages for better user feedback.

### Improvements to error handling:
* Updated the `run` function to explicitly return errors from recovered panics instead of exiting the process directly, improving testability and error reporting. (`cmd/cli/main.go`, [cmd/cli/main.goL43-R47](diffhunk://#diff-ed4d81d29a7267f93fd77e17993fd3491b9ef6ded18490b4514d10ed1d803bc2L43-R47))
* Enhanced the main function to distinguish between specific CLI exit codes and generic errors, ensuring consistent and meaningful exit behavior. (`cmd/cli/main.go`, [cmd/cli/main.goR25-R36](diffhunk://#diff-ed4d81d29a7267f93fd77e17993fd3491b9ef6ded18490b4514d10ed1d803bc2R25-R36))

### Enhanced test coverage:
* Added a unit test for the `run` function to verify panic recovery and ensure that the error message includes both the panic context and the underlying cause. (`cmd/cli/main_test.go`, [cmd/cli/main_test.goR1-R44](diffhunk://#diff-18879b570bdf373f6798e6f5d8c7f3645f906d2600e89d16a0f787b025c5ced1R1-R44))
* Introduced a comprehensive suite of tests for `cli.Parse`, covering various argument scenarios, including valid configurations, shorthand flags, help text, and invalid inputs. (`internal/cli/cli_test.go`, [internal/cli/cli_test.goR1-R133](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddR1-R133))